### PR TITLE
Replace satori UUID lib with gofrs UUID lib

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -152,7 +152,7 @@ func setup(t *testing.T) *athenaHarness {
 
 func (a *athenaHarness) setupTable() {
 	// tables cannot start with numbers or contain dashes
-	id, _ := uuid.NewV4()
+	id := uuid.Must(uuid.NewV4())
 	a.table = "t_" + strings.Replace(id.String(), "-", "_", -1)
 	a.mustExec(`CREATE EXTERNAL TABLE %[1]s (
 	nullValue string,


### PR DESCRIPTION
github.com/satori/go.uuid is abandoned. Replacing with github.com/gofrs/uuid which is an updated fork.